### PR TITLE
Introduced a new paradigm

### DIFF
--- a/demo/src/App.js
+++ b/demo/src/App.js
@@ -1,16 +1,21 @@
-import React from "react";
+import React, { useState } from "react";
 import "./style.css";
 
 import { useFocusTrap } from "react-use-focus-trap";
 
 export default function App() {
   const [trapRef] = useFocusTrap();
+  const [isOpen, setIsOpen] = useState(false);
+
+  function toggleModal() {
+    setIsOpen(!isOpen);
+  }
   return (
     <div>
       <section>
         <form>
           <input type="text" />
-          <input type="number" />
+          <input tabIndex="2" type="number" />
           <button>Foobar</button>
         </form>
         <p>
@@ -41,19 +46,22 @@ export default function App() {
           mauris.
         </p>
       </section>
-      <div className="modal" ref={trapRef}>
-        <form>
-          <input tabIndex="2" type="text" placeholder="2" />
-          <input tabIndex="0" type="number" placeholder="0" />
-          <input tabIndex="-1" type="number" placeholder="-1" />
-          <input tabIndex="0" type="number" placeholder="0" />
-          <input tabIndex="-1" type="number" placeholder="-1" />
-          <input tabIndex="1" type="number" placeholder="1" />
-          <button tabIndex="3" placeholder="3">
-            Foobar
-          </button>
-        </form>
-      </div>
+      <button onClick={toggleModal}>Open Modal</button>
+      {isOpen && (
+        <div className="modal" ref={trapRef}>
+          <form>
+            <input tabIndex="2" type="text" placeholder="2" />
+            <input tabIndex="0" type="number" placeholder="0" />
+            <input tabIndex="-1" type="number" placeholder="-1" />
+            <input tabIndex="0" type="number" placeholder="0" />
+            <input tabIndex="-1" type="number" placeholder="-1" />
+            <input tabIndex="1" type="number" placeholder="1" />
+            <button onClick={toggleModal} tabIndex="3" placeholder="3">
+              Close Modal
+            </button>
+          </form>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/constant.js
+++ b/src/constant.js
@@ -1,0 +1,17 @@
+export const FOCUSABLE_ELEMENT_SELECTORS = [
+  "a[href]",
+  "area[href]",
+  "input:not([disabled]):not([type=hidden])",
+  "select:not([disabled])",
+  "textarea:not([disabled])",
+  "button:not([disabled])",
+  "iframe",
+  "object",
+  "embed",
+  "*[tabindex]",
+  "*[contenteditable]",
+];
+
+export const MODAL_WRAPPER_CLASS = "use-focus-trap-modal";
+
+export const NON_TRAPPED_TABINDEX_ATTRIBUTE = "non-trapped-tabindex";

--- a/src/useFocusTrap.js
+++ b/src/useFocusTrap.js
@@ -1,88 +1,26 @@
-import { useCallback, useEffect, useRef } from "react";
-import { getTabIndexOfNode, sortByTabIndex } from "./util.js";
-
-const focusableElementsSelector =
-  "a[href], area[href], input:not([disabled]):not([type=hidden]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), iframe, object, embed, *[tabindex], *[contenteditable]";
-const TAB_KEY = 9;
+import { useEffect, useRef } from "react";
+import { MODAL_WRAPPER_CLASS } from "./constant.js";
+import {
+  removeElementFromTabOrder,
+  addElementToTabOrder,
+  buildNonTrappedElementsCssSelector,
+} from "./util.js";
 
 export function useFocusTrap() {
   const trapRef = useRef(null);
-
-  const selectNextFocusableElem = useCallback(
-    (
-      sortedFocusableElems,
-      currentIndex,
-      shiftKeyPressed = false,
-      skipCount = 0
-    ) => {
-      if (skipCount > sortedFocusableElems.length) {
-        // this means that it ran through all of elements but non was properly focusable
-        // hence we stop it to avoid running in an infinite loop
-        return false;
-      }
-
-      const backwards = !!shiftKeyPressed;
-      const maxIndex = sortedFocusableElems.length - 1;
-
-      if (!currentIndex) {
-        currentIndex =
-          sortedFocusableElems.indexOf(document.activeElement) ?? 0;
-      }
-
-      let nextIndex = backwards ? currentIndex - 1 : currentIndex + 1;
-      if (nextIndex > maxIndex) {
-        nextIndex = 0;
-      }
-
-      if (nextIndex < 0) {
-        nextIndex = maxIndex;
-      }
-
-      const newFocusElem = sortedFocusableElems[nextIndex];
-
-      newFocusElem.focus();
-
-      if (document.activeElement !== newFocusElem) {
-        // run another round
-        selectNextFocusableElem(
-          sortedFocusableElems,
-          nextIndex,
-          shiftKeyPressed,
-          skipCount + 1
-        );
-      }
-    }
-  );
-
-  // defining the trap function first
-  const trapper = useCallback((evt) => {
-    const trapRefElem = trapRef.current;
-    if (trapRefElem !== null) {
-      if (evt.which === TAB_KEY || evt.key === "Tab") {
-        evt.preventDefault();
-        const shiftKeyPressed = !!evt.shiftKey;
-        let focusableElems = Array.from(
-          trapRefElem.querySelectorAll(focusableElementsSelector)
-        ).filter(
-          (focusableElement) => getTabIndexOfNode(focusableElement) >= 0
-        ); // caching this is NOT a good idea in dynamic applications - so don't!
-        // now we need to sort it by tabIndex, highest first
-        focusableElems = focusableElems.sort(sortByTabIndex);
-
-        selectNextFocusableElem(focusableElems, undefined, shiftKeyPressed);
-      }
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
   useEffect(() => {
-    window.addEventListener("keydown", trapper);
-
+    if (!trapRef.current) {
+      return;
+    }
+    trapRef.current.classList.add(MODAL_WRAPPER_CLASS);
+    getNonTrappedFocusableElements().forEach(removeElementFromTabOrder);
     return () => {
-      window.removeEventListener("keydown", trapper);
+      getNonTrappedFocusableElements().forEach(addElementToTabOrder);
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
+  });
   return [trapRef];
+}
+
+function getNonTrappedFocusableElements() {
+  return document.body.querySelectorAll(buildNonTrappedElementsCssSelector());
 }

--- a/src/util.js
+++ b/src/util.js
@@ -1,40 +1,43 @@
-export function convertToIntOrFallback(stringToConvert) {
-  const parsed = parseInt(stringToConvert);
-  return parsed ? parsed : 0;
+import {
+  FOCUSABLE_ELEMENT_SELECTORS,
+  MODAL_WRAPPER_CLASS,
+  NON_TRAPPED_TABINDEX_ATTRIBUTE,
+} from "./constant.js";
+
+export function buildNonTrappedElementsCssSelector() {
+  return FOCUSABLE_ELEMENT_SELECTORS.reduce(
+    (selectorString, currenSelector) =>
+      `${selectorString}${currenSelector}:not(.${MODAL_WRAPPER_CLASS} ${currenSelector}), `,
+    ""
+  ).slice(0, -2);
 }
 
-export function sortByTabIndex(firstNode, secondNode) {
-  const tabIndexes = [firstNode, secondNode].map((node) =>
-    getTabIndexOfNode(node)
+export function getCustomNonTrappedTabindexAttribute() {
+  return `data-${NON_TRAPPED_TABINDEX_ATTRIBUTE}`;
+}
+
+export function addElementToTabOrder(node) {
+  const customPropertyValue = node.getAttribute(
+    getCustomNonTrappedTabindexAttribute()
   );
-  return tabIndexes
-    .map((tabIndexValue) =>
-      sanitizeTabIndexInput(tabIndexValue, Math.max(...tabIndexes))
-    )
-    .reduce((previousValue, currentValue) => previousValue - currentValue);
-}
-
-/**
- * Prepares a tab-index to be further processed for the tab order of the focus trap.
- * It can't be less than 0, because negative values can not be part of the tab order at all.
- * In case it's exactly 0 it actually needs to be higher than any positive (> 0) value, since tab-index=0 means "follow the system default order".
- * The default tab order comes _after_ special tab indexes (>0).
- * @param {number} tabIndex The index to sanitize
- * @param {number} highestPositiveTabIndex The largest number among the tab indexes from the same context
- * @throws An error if the tabIndex is less than 0
- * @returns Tha sanitized tab index
- * @see {@link https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/tabindex} for further information on the tabindex and its order
- */
-function sanitizeTabIndexInput(tabIndex, highestPositiveTabIndex) {
-  if (tabIndex < 0) {
-    throw new Error(
-      `Unable to sort given input. A negative value is not part of the tab order: ${tabIndex}`
-    );
+  // Do not overwrite the tab-index in case it hasn't been touched yet
+  if (!customPropertyValue) {
+    return;
   }
-  // 0 based tab indexes have a higher order than positive valued indicies, thus we add 1 to the max value
-  return tabIndex === 0 ? highestPositiveTabIndex + 1 : tabIndex;
+  node.setAttribute(
+    "tabindex",
+    sanitizeCustomPropertyValue(customPropertyValue)
+  );
 }
 
-export function getTabIndexOfNode(targetNode) {
-  return convertToIntOrFallback(targetNode.getAttribute("tabindex"));
+function sanitizeCustomPropertyValue(customPropertyValue) {
+  return customPropertyValue === "null" ? 0 : customPropertyValue;
+}
+
+export function removeElementFromTabOrder(node) {
+  node.setAttribute(
+    getCustomNonTrappedTabindexAttribute(),
+    node.getAttribute("tabindex")
+  );
+  node.setAttribute("tabindex", -1);
 }

--- a/test/util.test.js
+++ b/test/util.test.js
@@ -1,117 +1,117 @@
 import {
-  convertToIntOrFallback,
-  getTabIndexOfNode,
-  sortByTabIndex,
+  addElementToTabOrder,
+  removeElementFromTabOrder,
+  buildNonTrappedElementsCssSelector,
+  getCustomNonTrappedTabindexAttribute,
 } from "../src/util.js";
 import assert from "assert";
 import { JSDOM } from "jsdom";
 
 describe("Utility functions", function () {
-  describe("#convertToIntOrFallback", function () {
-    it("should convert a valid string to a number", function () {
-      assert.equal(convertToIntOrFallback("1"), 1);
-      assert.equal(convertToIntOrFallback("1337"), 1337);
-    });
-    it("should return 0 for an invalid string", function () {
-      assert.equal(convertToIntOrFallback("foobar"), 0);
-    });
-    it("should return 0 for type-mismatching arguments", function () {
-      assert.equal(convertToIntOrFallback({ foo: "bar" }), 0);
-      assert.equal(convertToIntOrFallback(null), 0);
-      assert.equal(convertToIntOrFallback(undefined), 0);
-    });
-    it("should pass through numbers", function () {
-      assert.equal(convertToIntOrFallback(0), 0);
-      assert.equal(convertToIntOrFallback(420), 420);
+  describe("#buildNonTrappedElementsCssSelector", function () {
+    it("should convert the selector list into a passable string", function () {
+      assert.equal(
+        buildNonTrappedElementsCssSelector(),
+        "a[href]:not(.use-focus-trap-modal a[href]), area[href]:not(.use-focus-trap-modal area[href]), input:not([disabled]):not([type=hidden]):not(.use-focus-trap-modal input:not([disabled]):not([type=hidden])), select:not([disabled]):not(.use-focus-trap-modal select:not([disabled])), textarea:not([disabled]):not(.use-focus-trap-modal textarea:not([disabled])), button:not([disabled]):not(.use-focus-trap-modal button:not([disabled])), iframe:not(.use-focus-trap-modal iframe), object:not(.use-focus-trap-modal object), embed:not(.use-focus-trap-modal embed), *[tabindex]:not(.use-focus-trap-modal *[tabindex]), *[contenteditable]:not(.use-focus-trap-modal *[contenteditable])"
+      );
     });
   });
-
-  describe("#sortByTabIndex", function () {
-    let tabIndexedNodes;
+  describe("#getCustomNonTrappedTabindexAttribute", function () {
+    it("should provide a correctly named custom attribute", function () {
+      assert.equal(
+        getCustomNonTrappedTabindexAttribute(),
+        "data-non-trapped-tabindex"
+      );
+    });
+  });
+  describe("#addElementToTabOrder", function () {
+    let tabIndexValues;
     beforeEach(function () {
       const dom = new JSDOM(
         `<html>
            <body>
-             <button id="one" tabindex="2">1</button>
-             <button id="two" tabindex="1">2</button>
-             <button id="three" tabindex="-1">3</button>
-             <button id="four" tabindex="0">4</button>
-             <button tabindex="-1">5</button>
-             <button tabindex="3">6</button>
-             <button tabindex="0">7</button>
+             <button class="to-test" data-non-trapped-tabindex="4" tabindex="2">Foo</button>
+             <button class="to-test" data-non-trapped-tabindex="5" tabindex="-1">Bar</button>
+             <button class="to-test" data-non-trapped-tabindex="6">Foobar</button>
+             <button class="to-test" tabindex="2">Foo</button>
+             <button class="to-test" data-non-trapped-tabindex="null" tabindex="-1">Bar</button>
+             <button class="to-test" data-non-trapped-tabindex="null">Bar</button>
            </body>
          </html>`
       );
-      tabIndexedNodes = dom.window.document.querySelectorAll("button");
+      tabIndexValues = Array.from(
+        dom.window.document.querySelectorAll(".to-test")
+      )
+        .map((node) => {
+          addElementToTabOrder(node);
+          return node;
+        })
+        .map((node) => node.getAttribute("tabindex"));
     });
-    it("should sort by tabindex value ascending", function () {
-      const firstNode = tabIndexedNodes.item(0),
-        secondNode = tabIndexedNodes.item(1);
-
-      // Sort secondNode 1 before firstNode 2
-      assert.equal(sortByTabIndex(firstNode, secondNode), 1);
-      assert.equal(sortByTabIndex(secondNode, firstNode), -1);
+    it("should pass the value from the custom attribute to the real tabindex", function () {
+      assert.deepEqual(
+        [tabIndexValues[0], tabIndexValues[1], tabIndexValues[2]],
+        [4, 5, 6]
+      );
     });
-    it("should put 0 values after positive values", function () {
-      const firstNode = tabIndexedNodes.item(0),
-        secondNode = tabIndexedNodes.item(3);
-
-      // Sort secondNode 0 after firstNode 2
-      assert.equal(sortByTabIndex(firstNode, secondNode), -1);
-      assert.equal(sortByTabIndex(secondNode, firstNode), 1);
+    it("should translate 'null' to 0", function () {
+      assert.deepEqual([tabIndexValues[4], tabIndexValues[5]], [0, 0]);
     });
-    it("should keep the original order of 0 values", function () {
-      const firstNode = tabIndexedNodes.item(3),
-        secondNode = tabIndexedNodes.item(6);
-
-      // Sort firstNode before secondNode
-      assert.equal(sortByTabIndex(firstNode, secondNode), 0);
-      // Sort secondNode before firstNode
-      assert.equal(sortByTabIndex(secondNode, firstNode), 0);
-    });
-    it("should throw an error when a negative value is passed", function () {
-      const firstNode = tabIndexedNodes.item(0),
-        secondNode = tabIndexedNodes.item(2);
-
-      assert.throws(() => sortByTabIndex(firstNode, secondNode));
-      assert.throws(() => sortByTabIndex(secondNode, firstNode));
-    });
-    it("should throw an error when a negative value is passed", function () {
-      const sortedArray = Array.from(tabIndexedNodes)
-        .filter((node) => node.getAttribute("tabindex") >= 0)
-        .sort(sortByTabIndex);
-
-      assert.deepEqual(sortedArray, [
-        tabIndexedNodes.item(1),
-        tabIndexedNodes.item(0),
-        tabIndexedNodes.item(5),
-        tabIndexedNodes.item(3),
-        tabIndexedNodes.item(6),
-      ]);
+    it("should not overwrite when custom attribute is not present", function () {
+      assert.equal(tabIndexValues[3], 2);
     });
   });
-
-  describe("#getTabIndexOfNode", function () {
-    let tabIndexedNodes;
+  describe("#removeElementFromTabOrder", function () {
+    let customAttributeValues;
+    let tabIndexValues;
     beforeEach(function () {
       const dom = new JSDOM(
         `<html>
            <body>
-             <button class="to-test" id="one" tabindex="2">1</button>
-             <button class="to-test" id="three" tabindex="-1">3</button>
-             <button class="to-test" id="four" tabindex="0">4</button>
-             <button class="to-test">5</button>
-             <span class="to-test">foobar</span>
+             <button class="to-test" data-non-trapped-tabindex="4" tabindex="2">Foo</button>
+             <button class="to-test" data-non-trapped-tabindex="5" tabindex="-1">Bar</button>
+             <button class="to-test" data-non-trapped-tabindex="6">Foobar</button>
+             <button class="to-test" tabindex="2">Foo</button>
+             <button class="to-test" tabindex="-1">Bar</button>
+             <button class="to-test">Foobar</button>
            </body>
          </html>`
       );
-      tabIndexedNodes = dom.window.document.querySelectorAll(".to-test");
-    });
-    it("should get the tab index as numbers of nodes", function () {
-      const tabIndexes = Array.from(tabIndexedNodes).map((node) =>
-        getTabIndexOfNode(node)
+      const tabIndexedNodes = Array.from(
+        dom.window.document.querySelectorAll(".to-test")
+      ).map((node) => {
+        removeElementFromTabOrder(node);
+        return node;
+      });
+      customAttributeValues = tabIndexedNodes.map(
+        (node) => node.dataset.nonTrappedTabindex
       );
-      assert.deepEqual(tabIndexes, [2, -1, 0, 0, 0]);
+      tabIndexValues = tabIndexedNodes.map((node) =>
+        node.getAttribute("tabindex")
+      );
+    });
+    it("should overwrite any existing custom attribute values", function () {
+      assert.deepEqual(
+        [
+          customAttributeValues[0],
+          customAttributeValues[1],
+          customAttributeValues[2],
+        ],
+        [2, -1, "null"]
+      );
+    });
+    it("should add custom attribute values with the value in the tabindex", function () {
+      assert.deepEqual(
+        [
+          customAttributeValues[3],
+          customAttributeValues[4],
+          customAttributeValues[5],
+        ],
+        [2, -1, "null"]
+      );
+    });
+    it("should overwrite any tabindex value with -1", function () {
+      assert.deepEqual(tabIndexValues, [-1, -1, -1, -1, -1, -1]);
     });
   });
 });


### PR DESCRIPTION
Instead of focusing on the elements to focus we remove the ones not to focus.
This way around has several advantages over the old approach.

Advantages:
- We make fewer assumptions and do not interfere with the browser configuration and implementation
   - A user might have configured another key than "tab" to change focus
   - 0 based tab-index means "follow the system order", which might or might not be "after any positive value" (it should be, but depending on the user and browser configuration, it might not)
   - Dev tools still work! (e.g. enabling "show tab-order")
   - Focus can be still moved outside of the document into the browser UI (which is debatable since in the official specs it's also not that way, but I feel that's an issue in the official specifications tbh)
   - Doesn't break tools like Vinium
- We have less logic to maintain
- Code is far more testable
   